### PR TITLE
Fix a doc typo on `gamma_abc_g1` in `VerifyingKey`

### DIFF
--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -50,7 +50,7 @@ pub struct VerifyingKey<E: PairingEngine> {
     pub gamma_g2: E::G2Affine,
     /// The `delta * H`, where `H` is the generator of `E::G2`.
     pub delta_g2: E::G2Affine,
-    /// The `gamma^{-1} * (alpha * a_i + beta * b_i + c_i) * H`, where `H` is the generator of `E::G1`.
+    /// The `gamma^{-1} * (beta * a_i + alpha * b_i + c_i) * H`, where `H` is the generator of `E::G1`.
     pub gamma_abc_g1: Vec<E::G1Affine>,
 }
 


### PR DESCRIPTION
According to [Groth16](https://eprint.iacr.org/2016/260.pdf), `gamma_abc_g1` is `gamma^{-1} * (beta * a_i + alpha * b_i + c_i) * H` instead of `gamma^{-1} * (alpha * a_i + beta * b_i + c_i) * H`.

This can also be seen from the code here:
```
let gamma_abc = cfg_iter!(a[..num_instance_variables])
        .zip(&b[..num_instance_variables])
        .zip(&c[..num_instance_variables])
        .map(|((a, b), c)| (beta * a + &(alpha * b) + c) * &gamma_inverse)
        .collect::<Vec<_>>();
```