### PR TITLE
Switch to the new optimization goal interface

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -3,7 +3,8 @@ use ark_ec::{msm::FixedBaseMSM, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, PrimeField, UniformRand, Zero};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_relations::r1cs::{
-    ConstraintSynthesizer, ConstraintSystem, Result as R1CSResult, SynthesisError, SynthesisMode,
+    ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, Result as R1CSResult,
+    SynthesisError, SynthesisMode,
 };
 use ark_std::{cfg_into_iter, cfg_iter};
 use rand::Rng;
@@ -46,6 +47,7 @@ where
 
     let setup_time = start_timer!(|| "Groth16::Generator");
     let cs = ConstraintSystem::new_ref();
+    cs.set_optimization_goal(OptimizationGoal::Constraints);
     cs.set_mode(SynthesisMode::Setup);
 
     // Synthesize the circuit.
@@ -54,7 +56,7 @@ where
     end_timer!(synthesis_time);
 
     let lc_time = start_timer!(|| "Inlining LCs");
-    cs.inline_all_lcs();
+    cs.finalize();
     end_timer!(lc_time);
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As the title. This PR uses the new interface for optimization: (1) setting an optimization goal and (2) calling `finalize` instead of `inline_all_lcs` before converting the R1CS system to a matrix.