### PR TITLE
Made E::G1 and E::G2 generators input to groth16::generate_parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ark-serialize = { version = "^0.2.0", default-features = false, features = [ "de
 ark-poly = { version = "^0.2.0", default-features = false }
 ark-std = { version = "^0.2.0", default-features = false }
 ark-relations = { version = "^0.2.0", default-features = false }
-ark-crypto-primitives = { version = "^0.2.0", branch = "main", default-features = false }
+ark-crypto-primitives = { version = "^0.2.0", default-features = false }
 ark-r1cs-std = { version = "^0.2.0", default-features = false, optional = true }
 
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -26,16 +26,30 @@ where
     let gamma = E::Fr::rand(rng);
     let delta = E::Fr::rand(rng);
 
-    generate_parameters::<E, C, R>(circuit, alpha, beta, gamma, delta, rng)
+    let g1_generator = E::G1Projective::rand(rng);
+    let g2_generator = E::G2Projective::rand(rng);
+
+    generate_parameters::<E, C, R>(
+        circuit,
+        alpha,
+        beta,
+        gamma,
+        delta,
+        g1_generator,
+        g2_generator,
+        rng,
+    )
 }
 
-/// Create parameters for a circuit, given some toxic waste.
+/// Create parameters for a circuit, given some toxic waste and group generators
 pub fn generate_parameters<E, C, R>(
     circuit: C,
     alpha: E::Fr,
     beta: E::Fr,
     gamma: E::Fr,
     delta: E::Fr,
+    g1_generator: E::G1Projective,
+    g2_generator: E::G2Projective,
     rng: &mut R,
 ) -> R1CSResult<ProvingKey<E>>
 where
@@ -102,9 +116,6 @@ where
         .collect::<Vec<_>>();
 
     drop(c);
-
-    let g1_generator = E::G1Projective::rand(rng);
-    let g2_generator = E::G2Projective::rand(rng);
 
     // Compute B window table
     let g2_time = start_timer!(|| "Compute G2 table");


### PR DESCRIPTION
I need this change because I'd like to generate `ProvingKey`s and `VerifyingKey`s for different circuits while ensuring they all share `alpha_g1`, `beta_g1`, `gamma_g1`, and `delta_g1` (and all the `_g2` versions too ofc). This is for some aggregate proving technique I'm working on.

A simple non-solution is to just pass an RNG with a known seed to `generate_parameters` whenever I need this property, but the issue is that `g1_generator` and `g2_generator` are not the first elements to be generated from the RNG (`t` is first), and so if the circuit sizes were different, we would get different generators.

So this is a simple solution for me: pass in the generators explicitly, and then use a real RNG to select `t`. An alternative solution is to just sample `g1_generator` and `g2_generator` at the top of the function instead of later. But that solution may be worse for me, because it would result in identical `t` values across circuits of the same size (which is bad? I can't tell).

Open to suggestions!