### PR TITLE
Replace `rand` with `ark_std::rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-featur
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
 derivative = { version = "2.0", features = ["use_core"], optional = true}
 
-rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -6,8 +6,8 @@ use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, Result as R1CSResult,
     SynthesisError, SynthesisMode,
 };
+use ark_std::rand::Rng;
 use ark_std::{cfg_into_iter, cfg_iter};
-use rand::Rng;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@ pub use self::{generator::*, prover::*, verifier::*};
 use ark_crypto_primitives::snark::*;
 use ark_ec::PairingEngine;
 use ark_relations::r1cs::{ConstraintSynthesizer, SynthesisError};
+use ark_std::rand::RngCore;
 use ark_std::{marker::PhantomData, vec::Vec};
-use rand::RngCore;
 
 /// The SNARK of [[Groth16]](https://eprint.iacr.org/2016/260.pdf).
 pub struct Groth16<E: PairingEngine> {

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -5,8 +5,8 @@ use ark_poly::GeneralEvaluationDomain;
 use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, Result as R1CSResult,
 };
+use ark_std::rand::Rng;
 use ark_std::{cfg_into_iter, cfg_iter, vec::Vec};
-use rand::Rng;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/tests/mimc.rs
+++ b/tests/mimc.rs
@@ -11,7 +11,7 @@
 )]
 
 // For randomness (during paramgen and proof generation)
-use rand::Rng;
+use ark_std::rand::Rng;
 
 // For benchmarking
 use std::time::{Duration, Instant};


### PR DESCRIPTION
## Description

This PR replaces the use of `rand` with `ark_std::rand`. 

---

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
