### PR TITLE
Add proof input preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Pending
+- [\#30](https://github.com/arkworks-rs/groth16/pull/30) Add proof input preprocessing
 
 ### Breaking changes
 - [\#21](https://github.com/arkworks-rs/groth16/pull/21) Change the `generate_parameters` interface to take generators as input.

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -17,13 +17,12 @@ pub fn prepare_verifying_key<E: PairingEngine>(vk: &VerifyingKey<E>) -> Prepared
     }
 }
 
-/// Verify a Groth16 proof `proof` against the prepared verification key `pvk`,
-/// with respect to the instance `public_inputs`.
-pub fn verify_proof<E: PairingEngine>(
+/// Prepare proof inputs for use with [`verify_proof_with_prepared_inputs`], wrt the prepared
+/// verification key `pvk` and instance public inputs.
+pub fn prepare_inputs<E: PairingEngine>(
     pvk: &PreparedVerifyingKey<E>,
-    proof: &Proof<E>,
     public_inputs: &[E::Fr],
-) -> R1CSResult<bool> {
+) -> R1CSResult<E::G1Projective> {
     if (public_inputs.len() + 1) != pvk.vk.gamma_abc_g1.len() {
         return Err(SynthesisError::MalformedVerifyingKey);
     }
@@ -33,10 +32,24 @@ pub fn verify_proof<E: PairingEngine>(
         g_ic.add_assign(&b.mul(i.into_repr()));
     }
 
+    Ok(g_ic)
+}
+
+/// Verify a Groth16 proof `proof` against the prepared verification key `pvk` and prepared public
+/// inputs. This should be preferred over [`verify_proof`] if the instance's public inputs are
+/// known in advance.
+pub fn verify_proof_with_prepared_inputs<E: PairingEngine>(
+    pvk: &PreparedVerifyingKey<E>,
+    proof: &Proof<E>,
+    prepared_inputs: &E::G1Projective,
+) -> R1CSResult<bool> {
     let qap = E::miller_loop(
         [
             (proof.a.into(), proof.b.into()),
-            (g_ic.into_affine().into(), pvk.gamma_g2_neg_pc.clone()),
+            (
+                prepared_inputs.into_affine().into(),
+                pvk.gamma_g2_neg_pc.clone(),
+            ),
             (proof.c.into(), pvk.delta_g2_neg_pc.clone()),
         ]
         .iter(),
@@ -45,4 +58,15 @@ pub fn verify_proof<E: PairingEngine>(
     let test = E::final_exponentiation(&qap).ok_or(SynthesisError::UnexpectedIdentity)?;
 
     Ok(test == pvk.alpha_g1_beta_g2)
+}
+
+/// Verify a Groth16 proof `proof` against the prepared verification key `pvk`,
+/// with respect to the instance `public_inputs`.
+pub fn verify_proof<E: PairingEngine>(
+    pvk: &PreparedVerifyingKey<E>,
+    proof: &Proof<E>,
+    public_inputs: &[E::Fr],
+) -> R1CSResult<bool> {
+    let prepared_inputs = prepare_inputs(pvk, public_inputs)?;
+    verify_proof_with_prepared_inputs(pvk, proof, &prepared_inputs)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

If a verifier knows the public inputs to a circuit, it can now preprocess them in advance. This is a useful trick for reducing the online time of protocols which require a verification.

This _does not_ implement the same functionality for circuits. This is because the circuit is implemented as a `SNARKGadget`, which does not expose input preprocessing methods. I'm not certain if all the NIZK schemes in arkworks have the ability to do this trick, so it might not be possible to extend `SNARKGadget`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
N/A
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
N/A
- [ ] Wrote unit tests
Existing verif unit tests also test the change
- [X] Updated relevant documentation in the code
- [X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
