### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
+# CHANGELOG
+
 ## Pending
-- [\#30](https://github.com/arkworks-rs/groth16/pull/30) Add proof input preprocessing.
 
 ### Breaking changes
+
+### Features
+
+### Improvements
+
+### Bug fixes
+
+## v0.3.0
+
+### Breaking changes
+
 - [\#21](https://github.com/arkworks-rs/groth16/pull/21) Change the `generate_parameters` interface to take generators as input.
 
 ### Features
+
+- [\#30](https://github.com/arkworks-rs/groth16/pull/30) Add proof input preprocessing.
 
 ### Improvements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-groth16"
-version = "0.2.0"
+version = "0.3.0"
 authors = [ "arkworks contributors" ]
 description = "An implementation of the Groth 2016 zkSNARK proof system"
 homepage = "https://arkworks.rs"
@@ -15,14 +15,14 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-ff = { version = "^0.2.0", default-features = false }
-ark-ec = { version = "^0.2.0", default-features = false }
-ark-serialize = { version = "^0.2.0", default-features = false, features = [ "derive" ] }
-ark-poly = { version = "^0.2.0", default-features = false }
-ark-std = { version = "^0.2.0", default-features = false }
-ark-relations = { version = "^0.2.0", default-features = false }
-ark-crypto-primitives = { version = "^0.2.0", default-features = false }
-ark-r1cs-std = { version = "^0.2.0", default-features = false, optional = true }
+ark-ff = { version = "^0.3.0", default-features = false }
+ark-ec = { version = "^0.3.0", default-features = false }
+ark-serialize = { version = "^0.3.0", default-features = false, features = [ "derive" ] }
+ark-poly = { version = "^0.3.0", default-features = false }
+ark-std = { version = "^0.3.0", default-features = false }
+ark-relations = { version = "^0.3.0", default-features = false }
+ark-crypto-primitives = { version = "^0.3.0", default-features = false }
+ark-r1cs-std = { version = "^0.3.0", default-features = false, optional = true }
 
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
 derivative = { version = "2.0", features = ["use_core"], optional = true}
@@ -31,13 +31,13 @@ rayon = { version = "1", optional = true }
 
 [dev-dependencies]
 csv = { version = "1" }
-ark-bls12-381 = { version = "^0.2.0", default-features = false, features = ["curve"] }
-ark-bls12-377 = { version = "^0.2.0", default-features = false, features = ["curve"] }
-ark-cp6-782 = { version = "^0.2.0", default-features = false }
-ark-mnt4-298 = { version = "^0.2.0", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-298 = { version = "^0.2.0", default-features = false, features = ["r1cs"] }
-ark-mnt4-753 = { version = "^0.2.0", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-753 = { version = "^0.2.0", default-features = false, features = ["r1cs"] }
+ark-bls12-381 = { version = "^0.3.0", default-features = false, features = ["curve"] }
+ark-bls12-377 = { version = "^0.3.0", default-features = false, features = ["curve"] }
+ark-cp6-782 = { version = "^0.3.0", default-features = false }
+ark-mnt4-298 = { version = "^0.3.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-298 = { version = "^0.3.0", default-features = false, features = ["r1cs"] }
+ark-mnt4-753 = { version = "^0.3.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-753 = { version = "^0.3.0", default-features = false, features = ["r1cs"] }
 
 [profile.release]
 opt-level = 3

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -142,11 +142,11 @@ where
     // Generate the R1CS proving key
     let proving_key_time = start_timer!(|| "Generate the R1CS proving key");
 
-    let alpha_g1 = g1_generator.mul(alpha.into());
-    let beta_g1 = g1_generator.mul(beta.into());
-    let beta_g2 = g2_generator.mul(beta.into());
-    let delta_g1 = g1_generator.mul(delta.into());
-    let delta_g2 = g2_generator.mul(delta.into());
+    let alpha_g1 = g1_generator.mul(&alpha.into_repr());
+    let beta_g1 = g1_generator.mul(&beta.into_repr());
+    let beta_g2 = g2_generator.mul(&beta.into_repr());
+    let delta_g1 = g1_generator.mul(&delta.into_repr());
+    let delta_g2 = g2_generator.mul(&delta.into_repr());
 
     // Compute the A-query
     let a_time = start_timer!(|| "Calculate A");
@@ -190,7 +190,7 @@ where
 
     // Generate R1CS verification key
     let verifying_key_time = start_timer!(|| "Generate the R1CS verification key");
-    let gamma_g2 = g2_generator.mul(gamma.into());
+    let gamma_g2 = g2_generator.mul(&gamma.into_repr());
     let gamma_abc_g1 = FixedBaseMSM::multi_scalar_mul::<E::G1Projective>(
         scalar_bits,
         g1_window,

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -86,7 +86,11 @@ where
 
     let l_aux_acc = VariableBaseMSM::multi_scalar_mul(&pk.l_query, &aux_assignment);
 
-    let r_s_delta_g1 = pk.delta_g1.into_projective().mul(&r.into_repr()).mul(&s.into_repr());
+    let r_s_delta_g1 = pk
+        .delta_g1
+        .into_projective()
+        .mul(&r.into_repr())
+        .mul(&s.into_repr());
 
     end_timer!(c_acc_time);
 

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -86,7 +86,7 @@ where
 
     let l_aux_acc = VariableBaseMSM::multi_scalar_mul(&pk.l_query, &aux_assignment);
 
-    let r_s_delta_g1 = pk.delta_g1.into_projective().mul(r.into()).mul(s.into());
+    let r_s_delta_g1 = pk.delta_g1.into_projective().mul(&r.into_repr()).mul(&s.into_repr());
 
     end_timer!(c_acc_time);
 
@@ -107,7 +107,7 @@ where
 
     let g_a = calculate_coeff(r_g1, &pk.a_query, pk.vk.alpha_g1, &assignment);
 
-    let s_g_a = g_a.mul(s.into());
+    let s_g_a = g_a.mul(&s.into_repr());
     end_timer!(a_acc_time);
 
     // Compute B in G1 if needed
@@ -127,7 +127,7 @@ where
     let b_g2_acc_time = start_timer!(|| "Compute B in G2");
     let s_g2 = pk.vk.delta_g2.mul(s);
     let g2_b = calculate_coeff(s_g2, &pk.b_g2_query, pk.vk.beta_g2, &assignment);
-    let r_g1_b = g1_b.mul(r.into());
+    let r_g1_b = g1_b.mul(&r.into_repr());
     drop(assignment);
 
     end_timer!(b_g2_acc_time);


### PR DESCRIPTION
## Description

This PR prepares `ark-groth16` for the release of v0.3.0.

Note that some code needs to be updated. Previously, one may use `mul(r.into())`, but now `mul(&r.into_repr())`. This is due to the introduction of `From<BigUint>` and `Into<BigUint>` to `PrimeField`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

n/a:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
