### PR TITLE
feat: allow using custom R1CS to QAP reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- [\#34](https://github.com/arkworks-rs/groth16/pull/34) Allow specifying custom R1CS to QAP reductions.
+
 ### Improvements
 
 ### Bug fixes
@@ -27,19 +29,23 @@
 ## v0.2.0
 
 ### Breaking changes
-- [\#4](https://github.com/arkworks-rs/groth16/pull/4) Change groth16's logic to implement the `SNARK` trait.
+
+- [\#4](https://github.com/arkworks-rs/groth16/pull/4) Change `groth16`'s logic to implement the `SNARK` trait.
 - Minimum version on crates from `arkworks-rs/algebra` and `arkworks-rs/curves` is now `v0.2.0`
 - [\#24](https://github.com/arkworks-rs/groth16/pull/24) Switch from `bench-utils` to `ark_std::perf_trace`
 
 ### Features
+
 - [\#5](https://github.com/arkworks-rs/groth16/pull/5) Add R1CS constraints for the groth16 verifier.
 - [\#8](https://github.com/arkworks-rs/groth16/pull/8) Add benchmarks for the prover
 - [\#16](https://github.com/arkworks-rs/groth16/pull/16) Add proof re-randomization
 
 ### Improvements
+
 - [\#9](https://github.com/arkworks-rs/groth16/pull/9) Improve memory consumption by manually dropping large vectors once they're no longer needed
 
 ### Bug fixes
+
 - [c9bc5519](https://github.com/arkworks-rs/groth16/commit/885b9b569522f59a7eb428d1095f442ec9bc5519) Fix parallel feature flag
 - [\#22](https://github.com/arkworks-rs/groth16/pull/22) Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    r1cs_to_qap::{QAPCalculator, R1CStoQAP},
+    r1cs_to_qap::{LibsnarkReduction, R1CStoQAP},
     ProvingKey, Vec, VerifyingKey,
 };
 use ark_ec::{msm::FixedBaseMSM, PairingEngine, ProjectiveCurve};
@@ -24,7 +24,7 @@ where
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
 {
-    generate_random_parameters_with_qap::<E, C, R, R1CStoQAP>(circuit, rng)
+    generate_random_parameters_with_qap::<E, C, R, LibsnarkReduction>(circuit, rng)
 }
 
 /// Generates a random common reference string for
@@ -38,7 +38,7 @@ where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
-    QAP: QAPCalculator,
+    QAP: R1CStoQAP,
 {
     let alpha = E::Fr::rand(rng);
     let beta = E::Fr::rand(rng);
@@ -76,7 +76,7 @@ where
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
 {
-    generate_parameters_with_qap::<E, C, R, R1CStoQAP>(
+    generate_parameters_with_qap::<E, C, R, LibsnarkReduction>(
         circuit,
         alpha,
         beta,
@@ -103,7 +103,7 @@ where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
-    QAP: QAPCalculator,
+    QAP: R1CStoQAP,
 {
     type D<F> = GeneralEvaluationDomain<F>;
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -216,9 +216,7 @@ where
         scalar_bits,
         g1_window,
         &g1_table,
-        &cfg_into_iter!(0..m_raw - 1)
-            .map(|i| zt * &delta_inverse * &t.pow([i as u64]))
-            .collect::<Vec<_>>(),
+        &QAP::h_query_scalars::<_, D<E::Fr>>(m_raw - 1, t, zt, delta_inverse)?,
     );
 
     end_timer!(h_time);

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -24,13 +24,13 @@ where
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
 {
-    generate_random_parameters_with_qap::<E, C, R, LibsnarkReduction>(circuit, rng)
+    generate_random_parameters_with_reduction::<E, C, R, LibsnarkReduction>(circuit, rng)
 }
 
 /// Generates a random common reference string for
-/// a circuit using the provided R1CS to QAP calculator
+/// a circuit using the provided R1CS-to-QAP reduction.
 #[inline]
-pub fn generate_random_parameters_with_qap<E, C, R, QAP>(
+pub fn generate_random_parameters_with_reduction<E, C, R, QAP>(
     circuit: C,
     rng: &mut R,
 ) -> R1CSResult<ProvingKey<E>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ extern crate ark_std;
 extern crate derivative;
 
 /// Reduce an R1CS instance to a *Quadratic Arithmetic Program* instance.
-pub(crate) mod r1cs_to_qap;
+pub mod r1cs_to_qap;
 
 /// Data structures used by the prover, verifier, and generator.
 pub mod data_structures;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,5 +1,5 @@
 use crate::{
-    r1cs_to_qap::{QAPCalculator, R1CStoQAP},
+    r1cs_to_qap::{LibsnarkReduction, R1CStoQAP},
     Proof, ProvingKey, VerifyingKey,
 };
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, PairingEngine, ProjectiveCurve};
@@ -26,7 +26,7 @@ where
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
 {
-    create_random_proof_with_qap::<E, C, R, R1CStoQAP>(circuit, pk, rng)
+    create_random_proof_with_qap::<E, C, R, LibsnarkReduction>(circuit, pk, rng)
 }
 
 /// Create a Groth16 proof that is zero-knowledge using the provided QAP calculator.
@@ -41,7 +41,7 @@ where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
-    QAP: QAPCalculator,
+    QAP: R1CStoQAP,
 {
     let r = E::Fr::rand(rng);
     let s = E::Fr::rand(rng);
@@ -56,7 +56,7 @@ where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
 {
-    create_proof_with_qap::<E, C, R1CStoQAP>(circuit, pk, E::Fr::zero(), E::Fr::zero())
+    create_proof_with_qap::<E, C, LibsnarkReduction>(circuit, pk, E::Fr::zero(), E::Fr::zero())
 }
 
 /// Create a Groth16 proof that is *not* zero-knowledge with the provided QAP calculator
@@ -68,7 +68,7 @@ pub fn create_proof_with_qap_no_zk<E, C, QAP>(
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
-    QAP: QAPCalculator,
+    QAP: R1CStoQAP,
 {
     create_proof_with_qap::<E, C, QAP>(circuit, pk, E::Fr::zero(), E::Fr::zero())
 }
@@ -85,7 +85,7 @@ where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
 {
-    create_proof_with_qap::<E, C, R1CStoQAP>(circuit, pk, r, s)
+    create_proof_with_qap::<E, C, LibsnarkReduction>(circuit, pk, r, s)
 }
 
 /// Create a Groth16 proof using randomness `r` and `s` and the provided QAP calculator.
@@ -99,7 +99,7 @@ pub fn create_proof_with_qap<E, C, QAP>(
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
-    QAP: QAPCalculator,
+    QAP: R1CStoQAP,
 {
     type D<F> = GeneralEvaluationDomain<F>;
 

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -26,13 +26,14 @@ where
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
 {
-    create_random_proof_with_qap::<E, C, R, LibsnarkReduction>(circuit, pk, rng)
+    create_random_proof_with_reduction::<E, C, R, LibsnarkReduction>(circuit, pk, rng)
 }
 
-/// Create a Groth16 proof that is zero-knowledge using the provided QAP calculator.
+/// Create a Groth16 proof that is zero-knowledge using the provided
+/// R1CS-to-QAP reduction.
 /// This method samples randomness for zero knowledges via `rng`.
 #[inline]
-pub fn create_random_proof_with_qap<E, C, R, QAP>(
+pub fn create_random_proof_with_reduction<E, C, R, QAP>(
     circuit: C,
     pk: &ProvingKey<E>,
     rng: &mut R,
@@ -46,22 +47,23 @@ where
     let r = E::Fr::rand(rng);
     let s = E::Fr::rand(rng);
 
-    create_proof_with_qap::<E, C, QAP>(circuit, pk, r, s)
+    create_proof_with_reduction::<E, C, QAP>(circuit, pk, r, s)
 }
 
 #[inline]
-/// Create a Groth16 proof that is *not* zero-knowledge
+/// Create a Groth16 proof that is *not* zero-knowledge.
 pub fn create_proof_no_zk<E, C>(circuit: C, pk: &ProvingKey<E>) -> R1CSResult<Proof<E>>
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
 {
-    create_proof_with_qap::<E, C, LibsnarkReduction>(circuit, pk, E::Fr::zero(), E::Fr::zero())
+    create_proof_with_reduction_no_zk::<E, C, LibsnarkReduction>(circuit, pk)
 }
 
-/// Create a Groth16 proof that is *not* zero-knowledge with the provided QAP calculator
+/// Create a Groth16 proof that is *not* zero-knowledge with the provided
+/// R1CS-to-QAP reduction.
 #[inline]
-pub fn create_proof_with_qap_no_zk<E, C, QAP>(
+pub fn create_proof_with_reduction_no_zk<E, C, QAP>(
     circuit: C,
     pk: &ProvingKey<E>,
 ) -> R1CSResult<Proof<E>>
@@ -70,7 +72,7 @@ where
     C: ConstraintSynthesizer<E::Fr>,
     QAP: R1CStoQAP,
 {
-    create_proof_with_qap::<E, C, QAP>(circuit, pk, E::Fr::zero(), E::Fr::zero())
+    create_proof_with_reduction::<E, C, QAP>(circuit, pk, E::Fr::zero(), E::Fr::zero())
 }
 
 #[inline]
@@ -85,12 +87,13 @@ where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
 {
-    create_proof_with_qap::<E, C, LibsnarkReduction>(circuit, pk, r, s)
+    create_proof_with_reduction::<E, C, LibsnarkReduction>(circuit, pk, r, s)
 }
 
-/// Create a Groth16 proof using randomness `r` and `s` and the provided QAP calculator.
+/// Create a Groth16 proof using randomness `r` and `s` and the provided
+/// R1CS-to-QAP reduction.
 #[inline]
-pub fn create_proof_with_qap<E, C, QAP>(
+pub fn create_proof_with_reduction<E, C, QAP>(
     circuit: C,
     pk: &ProvingKey<E>,
     r: E::Fr,

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -52,6 +52,13 @@ pub trait QAPCalculator {
     fn witness_map<F: PrimeField, D: EvaluationDomain<F>>(
         prover: ConstraintSystemRef<F>,
     ) -> Result<Vec<F>, SynthesisError>;
+
+    fn h_query_scalars<F: PrimeField, D: EvaluationDomain<F>>(
+        max_power: usize,
+        t: F,
+        zt: F,
+        delta_inverse: F,
+    ) -> Result<Vec<F>, SynthesisError>;
 }
 
 impl QAPCalculator for R1CStoQAP {
@@ -168,5 +175,17 @@ impl QAPCalculator for R1CStoQAP {
         domain.coset_ifft_in_place(&mut ab);
 
         Ok(ab)
+    }
+
+    fn h_query_scalars<F: PrimeField, D: EvaluationDomain<F>>(
+        max_power: usize,
+        t: F,
+        zt: F,
+        delta_inverse: F,
+    ) -> Result<Vec<F>, SynthesisError> {
+        let scalars = cfg_into_iter!(0..max_power)
+            .map(|i| zt * &delta_inverse * &t.pow([i as u64]))
+            .collect::<Vec<_>>();
+        Ok(scalars)
     }
 }

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -41,9 +41,7 @@ where
     return res;
 }
 
-pub struct R1CStoQAP;
-
-pub trait QAPCalculator {
+pub trait R1CStoQAP {
     fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(
         cs: ConstraintSystemRef<F>,
         t: &F,
@@ -61,7 +59,9 @@ pub trait QAPCalculator {
     ) -> Result<Vec<F>, SynthesisError>;
 }
 
-impl QAPCalculator for R1CStoQAP {
+pub(crate) struct LibsnarkReduction;
+
+impl R1CStoQAP for LibsnarkReduction {
     #[inline]
     #[allow(clippy::type_complexity)]
     fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -10,6 +10,7 @@ use core::ops::{AddAssign, Deref};
 use rayon::prelude::*;
 
 #[inline]
+/// Computes the inner product of `terms` with `assignment`.
 pub fn evaluate_constraint<'a, LHS, RHS, R>(terms: &'a [(LHS, usize)], assignment: &'a [RHS]) -> R
 where
     LHS: One + Send + Sync + PartialEq,
@@ -41,12 +42,16 @@ where
     return res;
 }
 
+/// Computes instance and witness reductions from R1CS to 
+/// Quadratic Arithmetic Programs (QAPs).
 pub trait R1CStoQAP {
+	/// Computes a QAP instance corresponding to the R1CS instance defined by `cs`.
     fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(
         cs: ConstraintSystemRef<F>,
         t: &F,
     ) -> Result<(Vec<F>, Vec<F>, Vec<F>, F, usize, usize), SynthesisError>;
 
+	/// Computes a QAP witness corresponding to the R1CS witness defined by `cs`.
     fn witness_map<F: PrimeField, D: EvaluationDomain<F>>(
         prover: ConstraintSystemRef<F>,
     ) -> Result<Vec<F>, SynthesisError>;
@@ -59,7 +64,8 @@ pub trait R1CStoQAP {
     ) -> Result<Vec<F>, SynthesisError>;
 }
 
-pub(crate) struct LibsnarkReduction;
+/// Computes the R1CS-to-QAP reduction defined in [`libsnark`](https://github.com/scipr-lab/libsnark/blob/2af440246fa2c3d0b1b0a425fb6abd8cc8b9c54d/libsnark/reductions/r1cs_to_qap/r1cs_to_qap.tcc).
+pub struct LibsnarkReduction;
 
 impl R1CStoQAP for LibsnarkReduction {
     #[inline]

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -10,7 +10,7 @@ use core::ops::{AddAssign, Deref};
 use rayon::prelude::*;
 
 #[inline]
-fn evaluate_constraint<'a, LHS, RHS, R>(terms: &'a [(LHS, usize)], assignment: &'a [RHS]) -> R
+pub fn evaluate_constraint<'a, LHS, RHS, R>(terms: &'a [(LHS, usize)], assignment: &'a [RHS]) -> R
 where
     LHS: One + Send + Sync + PartialEq,
     RHS: Send + Sync + core::ops::Mul<&'a LHS, Output = RHS> + Copy,
@@ -41,7 +41,7 @@ where
     return res;
 }
 
-pub(crate) struct R1CStoQAP;
+pub struct R1CStoQAP;
 
 pub trait QAPCalculator {
     fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -43,10 +43,21 @@ where
 
 pub(crate) struct R1CStoQAP;
 
-impl R1CStoQAP {
+pub trait QAPCalculator {
+    fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(
+        cs: ConstraintSystemRef<F>,
+        t: &F,
+    ) -> Result<(Vec<F>, Vec<F>, Vec<F>, F, usize, usize), SynthesisError>;
+
+    fn witness_map<F: PrimeField, D: EvaluationDomain<F>>(
+        prover: ConstraintSystemRef<F>,
+    ) -> Result<Vec<F>, SynthesisError>;
+}
+
+impl QAPCalculator for R1CStoQAP {
     #[inline]
     #[allow(clippy::type_complexity)]
-    pub(crate) fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(
+    fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(
         cs: ConstraintSystemRef<F>,
         t: &F,
     ) -> R1CSResult<(Vec<F>, Vec<F>, Vec<F>, F, usize, usize)> {
@@ -91,7 +102,7 @@ impl R1CStoQAP {
     }
 
     #[inline]
-    pub(crate) fn witness_map<F: PrimeField, D: EvaluationDomain<F>>(
+    fn witness_map<F: PrimeField, D: EvaluationDomain<F>>(
         prover: ConstraintSystemRef<F>,
     ) -> R1CSResult<Vec<F>> {
         let matrices = prover.to_matrices().unwrap();

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -42,20 +42,22 @@ where
     return res;
 }
 
-/// Computes instance and witness reductions from R1CS to 
+/// Computes instance and witness reductions from R1CS to
 /// Quadratic Arithmetic Programs (QAPs).
 pub trait R1CStoQAP {
-	/// Computes a QAP instance corresponding to the R1CS instance defined by `cs`.
+    /// Computes a QAP instance corresponding to the R1CS instance defined by `cs`.
     fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(
         cs: ConstraintSystemRef<F>,
         t: &F,
     ) -> Result<(Vec<F>, Vec<F>, Vec<F>, F, usize, usize), SynthesisError>;
 
-	/// Computes a QAP witness corresponding to the R1CS witness defined by `cs`.
+    /// Computes a QAP witness corresponding to the R1CS witness defined by `cs`.
     fn witness_map<F: PrimeField, D: EvaluationDomain<F>>(
         prover: ConstraintSystemRef<F>,
     ) -> Result<Vec<F>, SynthesisError>;
 
+    /// Computes the exponents that the generator uses to calculate base
+    /// elements which the prover later uses to compute `h(x)t(x)/delta`.
     fn h_query_scalars<F: PrimeField, D: EvaluationDomain<F>>(
         max_power: usize,
         t: F,


### PR DESCRIPTION
## Description

As discussed, it is potentially useful to allow customizing the R1CS to QAP conversion, for cases such as Circom's where they skip some of the FFTs.

## Implementation

This PR abstracts the R1CS to QAP to a trait and exposes methods for providing implementors of the trait. It maintains backwards compat.