### PR TITLE
feat: prove with matrices

### DIFF
--- a/src/prover.rs
+++ b/src/prover.rs
@@ -32,7 +32,7 @@ where
 
 type D<F> = GeneralEvaluationDomain<F>;
 
-/// Create a Groth16 proof using randomness `r` and `s` and 
+/// Create a Groth16 proof using randomness `r` and `s` and
 /// the provided R1CS-to-QAP reduction, using the provided
 /// R1CS constraint matrices.
 #[inline]

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -6,7 +6,7 @@ use ark_ec::{msm::VariableBaseMSM, AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, PrimeField, UniformRand, Zero};
 use ark_poly::GeneralEvaluationDomain;
 use ark_relations::r1cs::{
-    ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, Result as R1CSResult,
+    ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, Result as R1CSResult, ConstraintMatrices
 };
 use ark_std::rand::Rng;
 use ark_std::{cfg_into_iter, cfg_iter, vec::Vec};
@@ -28,6 +28,107 @@ where
 {
     create_random_proof_with_reduction::<E, C, R, LibsnarkReduction>(circuit, pk, rng)
 }
+
+
+
+/// Create a Groth16 proof using randomness `r` and `s` and the provided QAP calculator.
+#[inline]
+pub fn create_proof_with_qap_and_matrices<E, QAP>(
+    pk: &ProvingKey<E>,
+    r: E::Fr,
+    s: E::Fr,
+    matrices: &ConstraintMatrices<E::Fr>,
+    num_inputs: usize,
+    num_constraints: usize,
+    full_assignment: &[E::Fr],
+) -> R1CSResult<Proof<E>>
+    where
+        E: PairingEngine,
+        QAP: R1CStoQAP,
+{
+    type D<F> = GeneralEvaluationDomain<F>;
+
+    let prover_time = start_timer!(|| "Groth16::Prover");
+
+    let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
+    let h = QAP::witness_map_from_matrices::<E::Fr, D<E::Fr>>(matrices, num_inputs, num_constraints, full_assignment)?;
+    end_timer!(witness_map_time);
+    let h_assignment = cfg_into_iter!(h).map(|s| s.into()).collect::<Vec<_>>();
+    let c_acc_time = start_timer!(|| "Compute C");
+
+    let h_acc = VariableBaseMSM::multi_scalar_mul(&pk.h_query, &h_assignment);
+    drop(h_assignment);
+    // Compute C
+    let aux_assignment = cfg_iter!(full_assignment[num_inputs..])
+        .map(|s| s.into_repr())
+        .collect::<Vec<_>>();
+
+    let l_aux_acc = VariableBaseMSM::multi_scalar_mul(&pk.l_query, &aux_assignment);
+
+    let r_s_delta_g1 = pk
+        .delta_g1
+        .into_projective()
+        .mul(&r.into_repr())
+        .mul(&s.into_repr());
+
+    end_timer!(c_acc_time);
+
+    let input_assignment = full_assignment[1..num_inputs]
+        .iter()
+        .map(|s| s.into_repr())
+        .collect::<Vec<_>>();
+
+    let assignment = [&input_assignment[..], &aux_assignment[..]].concat();
+    drop(aux_assignment);
+
+    // Compute A
+    let a_acc_time = start_timer!(|| "Compute A");
+    let r_g1 = pk.delta_g1.mul(r);
+
+    let g_a = calculate_coeff(r_g1, &pk.a_query, pk.vk.alpha_g1, &assignment);
+
+    let s_g_a = g_a.mul(&s.into_repr());
+    end_timer!(a_acc_time);
+
+    // Compute B in G1 if needed
+    let g1_b = if !r.is_zero() {
+        let b_g1_acc_time = start_timer!(|| "Compute B in G1");
+        let s_g1 = pk.delta_g1.mul(s);
+        let g1_b = calculate_coeff(s_g1, &pk.b_g1_query, pk.beta_g1, &assignment);
+
+        end_timer!(b_g1_acc_time);
+
+        g1_b
+    } else {
+        E::G1Projective::zero()
+    };
+
+    // Compute B in G2
+    let b_g2_acc_time = start_timer!(|| "Compute B in G2");
+    let s_g2 = pk.vk.delta_g2.mul(s);
+    let g2_b = calculate_coeff(s_g2, &pk.b_g2_query, pk.vk.beta_g2, &assignment);
+    let r_g1_b = g1_b.mul(&r.into_repr());
+    drop(assignment);
+
+    end_timer!(b_g2_acc_time);
+
+    let c_time = start_timer!(|| "Finish C");
+    let mut g_c = s_g_a;
+    g_c += &r_g1_b;
+    g_c -= &r_s_delta_g1;
+    g_c += &l_aux_acc;
+    g_c += &h_acc;
+    end_timer!(c_time);
+
+    end_timer!(prover_time);
+
+    Ok(Proof {
+        a: g_a.into_affine(),
+        b: g2_b.into_affine(),
+        c: g_c.into_affine(),
+    })
+}
+
 
 /// Create a Groth16 proof that is zero-knowledge using the provided
 /// R1CS-to-QAP reduction.

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -6,7 +6,8 @@ use ark_ec::{msm::VariableBaseMSM, AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, PrimeField, UniformRand, Zero};
 use ark_poly::GeneralEvaluationDomain;
 use ark_relations::r1cs::{
-    ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, Result as R1CSResult, ConstraintMatrices
+    ConstraintMatrices, ConstraintSynthesizer, ConstraintSystem, OptimizationGoal,
+    Result as R1CSResult,
 };
 use ark_std::rand::Rng;
 use ark_std::{cfg_into_iter, cfg_iter, vec::Vec};
@@ -29,7 +30,7 @@ where
     create_random_proof_with_reduction::<E, C, R, LibsnarkReduction>(circuit, pk, rng)
 }
 
-
+type D<F> = GeneralEvaluationDomain<F>;
 
 /// Create a Groth16 proof using randomness `r` and `s` and the provided QAP calculator.
 #[inline]
@@ -42,24 +43,48 @@ pub fn create_proof_with_qap_and_matrices<E, QAP>(
     num_constraints: usize,
     full_assignment: &[E::Fr],
 ) -> R1CSResult<Proof<E>>
-    where
-        E: PairingEngine,
-        QAP: R1CStoQAP,
+where
+    E: PairingEngine,
+    QAP: R1CStoQAP,
 {
-    type D<F> = GeneralEvaluationDomain<F>;
-
     let prover_time = start_timer!(|| "Groth16::Prover");
-
     let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
-    let h = QAP::witness_map_from_matrices::<E::Fr, D<E::Fr>>(matrices, num_inputs, num_constraints, full_assignment)?;
+    let h = QAP::witness_map_from_matrices::<E::Fr, D<E::Fr>>(
+        matrices,
+        num_inputs,
+        num_constraints,
+        full_assignment,
+    )?;
     end_timer!(witness_map_time);
-    let h_assignment = cfg_into_iter!(h).map(|s| s.into()).collect::<Vec<_>>();
-    let c_acc_time = start_timer!(|| "Compute C");
+    let input_assignment = &full_assignment[1..num_inputs];
+    let aux_assignment = &full_assignment[num_inputs..];
+    let proof =
+        create_proof_with_assignment::<E, QAP>(pk, r, s, &h, input_assignment, aux_assignment)?;
+    end_timer!(prover_time);
 
+    Ok(proof)
+}
+
+#[inline]
+fn create_proof_with_assignment<E, QAP>(
+    pk: &ProvingKey<E>,
+    r: E::Fr,
+    s: E::Fr,
+    h: &[E::Fr],
+    input_assignment: &[E::Fr],
+    aux_assignment: &[E::Fr],
+) -> R1CSResult<Proof<E>>
+where
+    E: PairingEngine,
+    QAP: R1CStoQAP,
+{
+    let c_acc_time = start_timer!(|| "Compute C");
+    let h_assignment = cfg_into_iter!(h).map(|s| s.into_repr()).collect::<Vec<_>>();
     let h_acc = VariableBaseMSM::multi_scalar_mul(&pk.h_query, &h_assignment);
     drop(h_assignment);
+
     // Compute C
-    let aux_assignment = cfg_iter!(full_assignment[num_inputs..])
+    let aux_assignment = cfg_iter!(aux_assignment)
         .map(|s| s.into_repr())
         .collect::<Vec<_>>();
 
@@ -73,7 +98,7 @@ pub fn create_proof_with_qap_and_matrices<E, QAP>(
 
     end_timer!(c_acc_time);
 
-    let input_assignment = full_assignment[1..num_inputs]
+    let input_assignment = input_assignment
         .iter()
         .map(|s| s.into_repr())
         .collect::<Vec<_>>();
@@ -120,15 +145,12 @@ pub fn create_proof_with_qap_and_matrices<E, QAP>(
     g_c += &h_acc;
     end_timer!(c_time);
 
-    end_timer!(prover_time);
-
     Ok(Proof {
         a: g_a.into_affine(),
         b: g2_b.into_affine(),
         c: g_c.into_affine(),
     })
 }
-
 
 /// Create a Groth16 proof that is zero-knowledge using the provided
 /// R1CS-to-QAP reduction.
@@ -205,8 +227,6 @@ where
     C: ConstraintSynthesizer<E::Fr>,
     QAP: R1CStoQAP,
 {
-    type D<F> = GeneralEvaluationDomain<F>;
-
     let prover_time = start_timer!(|| "Groth16::Prover");
     let cs = ConstraintSystem::new_ref();
 
@@ -226,84 +246,20 @@ where
     let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
     let h = QAP::witness_map::<E::Fr, D<E::Fr>>(cs.clone())?;
     end_timer!(witness_map_time);
-    let h_assignment = cfg_into_iter!(h).map(|s| s.into()).collect::<Vec<_>>();
-    let c_acc_time = start_timer!(|| "Compute C");
 
-    let h_acc = VariableBaseMSM::multi_scalar_mul(&pk.h_query, &h_assignment);
-    drop(h_assignment);
-    // Compute C
     let prover = cs.borrow().unwrap();
-    let aux_assignment = cfg_iter!(prover.witness_assignment)
-        .map(|s| s.into_repr())
-        .collect::<Vec<_>>();
-
-    let l_aux_acc = VariableBaseMSM::multi_scalar_mul(&pk.l_query, &aux_assignment);
-
-    let r_s_delta_g1 = pk
-        .delta_g1
-        .into_projective()
-        .mul(&r.into_repr())
-        .mul(&s.into_repr());
-
-    end_timer!(c_acc_time);
-
-    let input_assignment = prover.instance_assignment[1..]
-        .iter()
-        .map(|s| s.into_repr())
-        .collect::<Vec<_>>();
-
-    drop(prover);
-    drop(cs);
-
-    let assignment = [&input_assignment[..], &aux_assignment[..]].concat();
-    drop(aux_assignment);
-
-    // Compute A
-    let a_acc_time = start_timer!(|| "Compute A");
-    let r_g1 = pk.delta_g1.mul(r);
-
-    let g_a = calculate_coeff(r_g1, &pk.a_query, pk.vk.alpha_g1, &assignment);
-
-    let s_g_a = g_a.mul(&s.into_repr());
-    end_timer!(a_acc_time);
-
-    // Compute B in G1 if needed
-    let g1_b = if !r.is_zero() {
-        let b_g1_acc_time = start_timer!(|| "Compute B in G1");
-        let s_g1 = pk.delta_g1.mul(s);
-        let g1_b = calculate_coeff(s_g1, &pk.b_g1_query, pk.beta_g1, &assignment);
-
-        end_timer!(b_g1_acc_time);
-
-        g1_b
-    } else {
-        E::G1Projective::zero()
-    };
-
-    // Compute B in G2
-    let b_g2_acc_time = start_timer!(|| "Compute B in G2");
-    let s_g2 = pk.vk.delta_g2.mul(s);
-    let g2_b = calculate_coeff(s_g2, &pk.b_g2_query, pk.vk.beta_g2, &assignment);
-    let r_g1_b = g1_b.mul(&r.into_repr());
-    drop(assignment);
-
-    end_timer!(b_g2_acc_time);
-
-    let c_time = start_timer!(|| "Finish C");
-    let mut g_c = s_g_a;
-    g_c += &r_g1_b;
-    g_c -= &r_s_delta_g1;
-    g_c += &l_aux_acc;
-    g_c += &h_acc;
-    end_timer!(c_time);
+    let proof = create_proof_with_assignment::<E, QAP>(
+        pk,
+        r,
+        s,
+        &h,
+        &prover.instance_assignment[1..],
+        &prover.witness_assignment,
+    )?;
 
     end_timer!(prover_time);
 
-    Ok(Proof {
-        a: g_a.into_affine(),
-        b: g2_b.into_affine(),
-        c: g_c.into_affine(),
-    })
+    Ok(proof)
 }
 
 /// Given a Groth16 proof, returns a fresh proof of the same statement. For a proof π of a

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -32,9 +32,11 @@ where
 
 type D<F> = GeneralEvaluationDomain<F>;
 
-/// Create a Groth16 proof using randomness `r` and `s` and the provided QAP calculator.
+/// Create a Groth16 proof using randomness `r` and `s` and 
+/// the provided R1CS-to-QAP reduction, using the provided
+/// R1CS constraint matrices.
 #[inline]
-pub fn create_proof_with_qap_and_matrices<E, QAP>(
+pub fn create_proof_with_reduction_and_matrices<E, QAP>(
     pk: &ProvingKey<E>,
     r: E::Fr,
     s: E::Fr,

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -3,7 +3,9 @@ use ark_poly::EvaluationDomain;
 use ark_std::{cfg_iter, cfg_iter_mut, vec};
 
 use crate::Vec;
-use ark_relations::r1cs::{ConstraintSystemRef, Result as R1CSResult, SynthesisError, ConstraintMatrices};
+use ark_relations::r1cs::{
+    ConstraintMatrices, ConstraintSystemRef, Result as R1CSResult, SynthesisError,
+};
 use core::ops::{AddAssign, Deref};
 
 #[cfg(feature = "parallel")]
@@ -51,7 +53,7 @@ pub trait R1CStoQAP {
         t: &F,
     ) -> Result<(Vec<F>, Vec<F>, Vec<F>, F, usize, usize), SynthesisError>;
 
-     #[inline]
+    #[inline]
     /// Computes a QAP witness corresponding to the R1CS witness defined by `cs`.
     fn witness_map<F: PrimeField, D: EvaluationDomain<F>>(
         prover: ConstraintSystemRef<F>,
@@ -67,9 +69,14 @@ pub trait R1CStoQAP {
             prover.instance_assignment.as_slice(),
             prover.witness_assignment.as_slice(),
         ]
-            .concat();
+        .concat();
 
-        Self::witness_map_from_matrices::<F, D>(&matrices, num_inputs, num_constraints, &full_assignment)
+        Self::witness_map_from_matrices::<F, D>(
+            &matrices,
+            num_inputs,
+            num_constraints,
+            &full_assignment,
+        )
     }
 
     /// Computes a QAP witness corresponding to the R1CS witness defined by `cs`.
@@ -79,7 +86,6 @@ pub trait R1CStoQAP {
         num_constraints: usize,
         full_assignment: &[F],
     ) -> R1CSResult<Vec<F>>;
-
 
     /// Computes the exponents that the generator uses to calculate base
     /// elements which the prover later uses to compute `h(x)t(x)/delta`.


### PR DESCRIPTION
# Problem

Previously, we could not pre-load the Constraint Matrices (e.g. such as in the case of SnarkJS outputting ZKey files containing the coeffs). This PR enables this

# How
* extends the R1CStoQAP trait to directly compute the witness map from the Constraint Matrices
* Creates a new function `create_proof_with_qap_and_matrices` & refactors the proof generation to be shared between the `_matrices` and `_with_reduction` call