### PR TITLE
Bump all deps to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ edition = "2021"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-ff = { version = "0.4.0-alpha", default-features = false }
-ark-ec = { version = "0.4.0-alpha", default-features = false }
-ark-serialize = { version = "0.4.0-alpha", default-features = false, features = [ "derive" ] }
-ark-poly = { version = "0.4.0-alpha", default-features = false }
-ark-std = { version = "0.4.0-alpha", default-features = false }
-ark-relations = { version = "0.4.0-alpha", default-features = false }
-ark-crypto-primitives = { version = "0.4.0-alpha", default-features = false }
-ark-r1cs-std = { version = "0.4.0-alpha", default-features = false, optional = true }
+ark-ff = { version = "0.4.0", default-features = false }
+ark-ec = { version = "0.4.0", default-features = false }
+ark-serialize = { version = "0.4.0", default-features = false, features = [ "derive" ] }
+ark-poly = { version = "0.4.0", default-features = false }
+ark-std = { version = "0.4.0", default-features = false }
+ark-relations = { version = "0.4.0", default-features = false }
+ark-crypto-primitives = { version = "0.4.0", default-features = false, features = ["snark"] }
+ark-r1cs-std = { version = "0.4.0", default-features = false, optional = true }
 
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
 derivative = { version = "2.0", features = ["use_core"], optional = true}
@@ -31,14 +31,14 @@ rayon = { version = "1", optional = true }
 
 [dev-dependencies]
 csv = { version = "1" }
-ark-bls12-381 = { version = "0.4.0-alpha", default-features = false, features = ["curve"] }
-ark-bls12-377 = { version = "0.4.0-alpha", default-features = false, features = ["curve"] }
-ark-cp6-782 = { version = "0.4.0-alpha", default-features = false }
-ark-mnt4-298 = { version = "0.4.0-alpha", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-298 = { version = "0.4.0-alpha", default-features = false, features = ["r1cs"] }
-ark-mnt4-753 = { version = "0.4.0-alpha", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-753 = { version = "0.4.0-alpha", default-features = false, features = ["r1cs"] }
-ark-r1cs-std = { version = "0.4.0-alpha", default-features = false }
+ark-bls12-381 = { version = "0.4.0", default-features = false, features = ["curve"] }
+ark-bls12-377 = { version = "0.4.0", default-features = false, features = ["curve"] }
+ark-cp6-782 = { version = "0.4.0", default-features = false }
+ark-mnt4-298 = { version = "0.4.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-298 = { version = "0.4.0", default-features = false, features = ["r1cs"] }
+ark-mnt4-753 = { version = "0.4.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-753 = { version = "0.4.0", default-features = false, features = ["r1cs"] }
+ark-r1cs-std = { version = "0.4.0", default-features = false }
 
 [features]
 default = ["parallel"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,7 +3,7 @@
 // where N is the number of threads you want to use (N = 1 for single-thread).
 
 use ark_bls12_381::{Bls12_381, Fr as BlsFr};
-use ark_crypto_primitives::SNARK;
+use ark_crypto_primitives::snark::SNARK;
 use ark_ff::{PrimeField, UniformRand};
 use ark_groth16::Groth16;
 use ark_mnt4_298::{Fr as MNT4Fr, MNT4_298};


### PR DESCRIPTION
Bumped from `-alpha`.

Needed this because I was getting weird errors like "`Bls12_381` doesn't impl `PairingEngine`". This was because my `Bls12_381` was 0.4 and the groth16 `PairingEngine` was 0.3.