### PR TITLE
introduce lagrange basis commitments

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -3,7 +3,7 @@ use core::iter;
 use crate::{r1cs_to_qap::R1CSToQAP, Groth16, ProvingKey, Vec, VerifyingKey};
 use ark_ec::AffineRepr;
 use ark_ec::{pairing::Pairing, scalar_mul::fixed_base::FixedBase, CurveGroup, Group};
-use ark_ff::{Field, PrimeField, UniformRand, Zero, FftField};
+use ark_ff::{FftField, Field, PrimeField, UniformRand, Zero};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, Result as R1CSResult,
@@ -197,7 +197,8 @@ impl<E: Pairing, QAP: R1CSToQAP> Groth16<E, QAP> {
         );
 
         let coset_domain = domain.get_coset(E::ScalarField::GENERATOR).unwrap();
-        let h_query = compute_lagrange_basis_commitments_over_domain::<E::G1Affine>(&coset_domain, &h_query);
+        let h_query =
+            compute_lagrange_basis_commitments_over_domain::<E::G1Affine>(&coset_domain, &h_query);
 
         end_timer!(h_time);
 

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -207,8 +207,6 @@ impl R1CSToQAP for LibsnarkReduction {
             *ab_i *= &vanishing_polynomial_over_coset;
         });
 
-        coset_domain.ifft_in_place(&mut ab);
-
         Ok(ab)
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR removes last coset_ifft from "witness_map_from_matrices" function by storing commitments of lagrange basis in coset instead of just powers of toxic waste. 
