### PR TITLE
Circom witness generation is different than arkworks; cannot skip witness elements

### DIFF
--- a/src/prover.rs
+++ b/src/prover.rs
@@ -63,7 +63,7 @@ impl<E: Pairing, QAP: R1CSToQAP> Groth16<E, QAP> {
         let h_assignment = cfg_into_iter!(h)
             .map(|s| s.into_bigint())
             .collect::<Vec<_>>();
-        let h_acc = E::G1::msm_bigint(&pk.h_query, &h_assignment[..h_assignment.len() - 1]);
+        let h_acc = E::G1::msm_bigint(&pk.h_query, &h_assignment);
         drop(h_assignment);
 
         // Compute C


### PR DESCRIPTION
uses full domain instead of domain-1 elements

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fix to the failing verification in https://github.com/arkworks-rs/circom-compat/pull/68

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
