### PR TITLE
Remove `ark-relations/std` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ ark-r1cs-std = { version = "0.4.0", default-features = false }
 
 [features]
 default = ["parallel"]
-std = ["ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-relations/std", "ark-crypto-primitives/std", "ark-std/std" ]
+std = ["ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-crypto-primitives/std", "ark-std/std" ]
 parallel = ["std", "ark-ff/parallel", "ark-poly/parallel", "ark-ec/parallel", "ark-crypto-primitives/parallel", "ark-std/parallel", "rayon"]
 r1cs = [ "ark-crypto-primitives/r1cs", "ark-r1cs-std", "tracing", "derivative" ]
 print-trace = [ "ark-std/print-trace" ]


### PR DESCRIPTION
## Description

The `std` feature in ark-relations pulls in the hefty, and currently outdated (https://github.com/arkworks-rs/snark/issues/356), dependency on tracing-subscriber. Luckily, this dependency does not seem to be needed here at all.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
