### PR TITLE
chore: bump version and deps to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-groth16"
-version = "0.4.0"
+version = "0.5.0"
 authors = [ "arkworks contributors" ]
 description = "An implementation of the Groth 2016 zkSNARK proof system"
 homepage = "https://arkworks.rs"
@@ -15,14 +15,14 @@ edition = "2021"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-ff = { version = "0.4.0", default-features = false }
-ark-ec = { version = "0.4.0", default-features = false }
-ark-serialize = { version = "0.4.0", default-features = false, features = [ "derive" ] }
-ark-poly = { version = "0.4.0", default-features = false }
-ark-std = { version = "0.4.0", default-features = false }
-ark-relations = { version = "0.4.0", default-features = false }
-ark-crypto-primitives = { version = "0.4.0", default-features = false, features = ["snark", "sponge"] }
-ark-r1cs-std = { version = "0.4.0", default-features = false, optional = true }
+ark-ff = { version = "0.5.0", default-features = false }
+ark-ec = { version = "0.5.0", default-features = false }
+ark-serialize = { version = "0.5.0", default-features = false, features = [ "derive" ] }
+ark-poly = { version = "0.5.0", default-features = false }
+ark-std = { version = "0.5.0", default-features = false }
+ark-relations = { version = "0.5.0", default-features = false }
+ark-crypto-primitives = { version = "0.5.0", default-features = false, features = ["snark", "sponge"] }
+ark-r1cs-std = { version = "0.5.0", default-features = false, optional = true }
 
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
 derivative = { version = "2.0", features = ["use_core"], optional = true}
@@ -31,15 +31,15 @@ rayon = { version = "1", optional = true }
 
 [dev-dependencies]
 csv = { version = "1" }
-ark-bls12-381 = { version = "0.4.0", default-features = false, features = ["curve"] }
-ark-bls12-377 = { version = "0.4.0", default-features = false, features = ["curve"] }
-ark-bn254 = { version = "0.4.0", default-features = false, features = ["curve"] }
-ark-bw6-761 = { version = "0.4.0", default-features = false }
-ark-mnt4-298 = { version = "0.4.0", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-298 = { version = "0.4.0", default-features = false, features = ["r1cs"] }
-ark-mnt4-753 = { version = "0.4.0", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-753 = { version = "0.4.0", default-features = false, features = ["r1cs"] }
-ark-r1cs-std = { version = "0.4.0", default-features = false }
+ark-bls12-381 = { version = "0.5.0", default-features = false, features = ["curve"] }
+ark-bls12-377 = { version = "0.5.0", default-features = false, features = ["curve"] }
+ark-bn254 = { version = "0.5.0", default-features = false, features = ["curve"] }
+ark-bw6-761 = { version = "0.5.0", default-features = false }
+ark-mnt4-298 = { version = "0.5.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-298 = { version = "0.5.0", default-features = false, features = ["r1cs"] }
+ark-mnt4-753 = { version = "0.5.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-753 = { version = "0.5.0", default-features = false, features = ["r1cs"] }
+ark-r1cs-std = { version = "0.5.0", default-features = false }
 
 [features]
 default = ["parallel"]
@@ -78,25 +78,3 @@ lto = "thin"
 incremental = true
 debug-assertions = true
 debug = true
-
-
-[patch.crates-io]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-mnt4-298 = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-mnt6-298 = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-mnt4-753 = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-mnt6-753 = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-bw6-761 = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-bn254 = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-std = { git = "https://github.com/arkworks-rs/std/" }
-
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
-ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives/" }
-
-ark-relations = { git = "https://github.com/arkworks-rs/snark/" }
-ark-snark = { git = "https://github.com/arkworks-rs/snark/" }


### PR DESCRIPTION
Closes: https://github.com/arkworks-rs/groth16/issues/72

Sorry for dropping this on you, but it seems like the easiest way to make the project compilable again. Please feel free to disregard if I did something wrong on my end that ended up in a compilation failure.