### PR TITLE
Fix syntax errors in derivative attribute

### DIFF
--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -40,9 +40,9 @@ pub struct ProofVar<E: Pairing, P: PairingVar<E>> {
 
 /// A variable representing the Groth16 verifying key in the constraint system.
 #[derive(Derivative)]
-#[derivative(Clone(
-    bound = "P::G1Var: Clone, P::GTVar: Clone, P::G1PreparedVar: Clone, P::G2PreparedVar: Clone"
-))]
+#[derivative(
+    Clone(bound = "P::G1Var: Clone, P::GTVar: Clone, P::G1PreparedVar: Clone, P::G2PreparedVar: Clone")
+)]
 pub struct VerifyingKeyVar<E: Pairing, P: PairingVar<E>> {
     #[doc(hidden)]
     pub alpha_g1: P::G1Var,
@@ -114,7 +114,7 @@ where
 #[derive(Derivative)]
 #[derivative(
     Clone(bound = "P::G1Var: Clone, P::GTVar: Clone, P::G1PreparedVar: Clone, \
-    P::G2PreparedVar: Clone, ")
+    P::G2PreparedVar: Clone")
 )]
 pub struct PreparedVerifyingKeyVar<E: Pairing, P: PairingVar<E>> {
     #[doc(hidden)]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixed syntax errors in the src/constraints.rs file by removing trailing commas in #[derivative] attributes for VerifyingKeyVar and PreparedVerifyingKeyVar structures. 

It should prevent potential compiler warnings and ensure proper code formatting.

---

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (N/A - syntax fix only, no functional changes)
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the Pending section in CHANGELOG.md (N/A - minor syntax fix)
- [x] Re-reviewed Files changed in the Github PR explorer
