### PR TITLE
Fix Clippy warnings throughout the codebase

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -12,6 +12,22 @@ use ark_std::{cfg_into_iter, cfg_iter};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+/// Configuration for Groth16 parameter generation
+pub struct ParameterGenConfig<E: Pairing> {
+    /// Alpha parameter (toxic waste)
+    pub alpha: E::ScalarField,
+    /// Beta parameter (toxic waste)
+    pub beta: E::ScalarField,
+    /// Gamma parameter (toxic waste)
+    pub gamma: E::ScalarField,
+    /// Delta parameter (toxic waste)
+    pub delta: E::ScalarField,
+    /// G1 generator
+    pub g1_generator: E::G1,
+    /// G2 generator
+    pub g2_generator: E::G2,
+}
+
 impl<E: Pairing, QAP: R1CSToQAP> Groth16<E, QAP> {
     /// Generates a random common reference string for
     /// a circuit using the provided R1CS-to-QAP reduction.
@@ -31,27 +47,22 @@ impl<E: Pairing, QAP: R1CSToQAP> Groth16<E, QAP> {
         let g1_generator = E::G1::rand(rng);
         let g2_generator = E::G2::rand(rng);
 
-        Self::generate_parameters_with_qap(
-            circuit,
+        let config = ParameterGenConfig {
             alpha,
             beta,
             gamma,
             delta,
             g1_generator,
             g2_generator,
-            rng,
-        )
+        };
+
+        Self::generate_parameters_with_qap(circuit, config, rng)
     }
 
     /// Create parameters for a circuit, given some toxic waste, R1CS to QAP calculator and group generators
     pub fn generate_parameters_with_qap<C>(
         circuit: C,
-        alpha: E::ScalarField,
-        beta: E::ScalarField,
-        gamma: E::ScalarField,
-        delta: E::ScalarField,
-        g1_generator: E::G1,
-        g2_generator: E::G2,
+        config: ParameterGenConfig<E>,
         rng: &mut impl Rng,
     ) -> R1CSResult<ProvingKey<E>>
     where
@@ -63,6 +74,16 @@ impl<E: Pairing, QAP: R1CSToQAP> Groth16<E, QAP> {
         let cs = ConstraintSystem::new_ref();
         cs.set_optimization_goal(OptimizationGoal::Constraints);
         cs.set_mode(SynthesisMode::Setup);
+
+        // Unpack configuration values
+        let ParameterGenConfig {
+            alpha,
+            beta,
+            gamma,
+            delta,
+            g1_generator,
+            g2_generator,
+        } = config;
 
         // Synthesize the circuit.
         let synthesis_time = start_timer!(|| "Constraint synthesis");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ impl<E: Pairing, QAP: R1CSToQAP> SNARK<E::ScalarField> for Groth16<E, QAP> {
         x: &[E::ScalarField],
         proof: &Self::Proof,
     ) -> Result<bool, Self::Error> {
-        Ok(Self::verify_proof(&circuit_pvk, proof, &x)?)
+        Self::verify_proof(circuit_pvk, proof, x)
     }
 }
 

--- a/src/r1cs_to_qap.rs
+++ b/src/r1cs_to_qap.rs
@@ -11,6 +11,9 @@ use core::ops::Deref;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+/// Type alias for the complex QAP instance result
+pub type QapInstanceResult<F> = Result<(Vec<F>, Vec<F>, Vec<F>, F, usize, usize), SynthesisError>;
+
 #[inline]
 /// Computes the inner product of `terms` with `assignment`.
 ///
@@ -73,7 +76,7 @@ pub trait R1CSToQAP {
     fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(
         cs: ConstraintSystemRef<F>,
         t: &F,
-    ) -> Result<(Vec<F>, Vec<F>, Vec<F>, F, usize, usize), SynthesisError>;
+    ) -> QapInstanceResult<F>;
 
     #[inline]
     /// Computes a QAP witness corresponding to the R1CS witness defined by `cs`.
@@ -128,7 +131,7 @@ impl R1CSToQAP for LibsnarkReduction {
     fn instance_map_with_evaluation<F: PrimeField, D: EvaluationDomain<F>>(
         cs: ConstraintSystemRef<F>,
         t: &F,
-    ) -> R1CSResult<(Vec<F>, Vec<F>, Vec<F>, F, usize, usize)> {
+    ) -> QapInstanceResult<F> {
         let matrices = cs.to_matrices().unwrap();
         let domain_size = cs.num_constraints() + cs.num_instance_variables();
         let domain = D::new(domain_size).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
@@ -188,8 +191,8 @@ impl R1CSToQAP for LibsnarkReduction {
             .zip(cfg_iter!(&matrices.a))
             .zip(cfg_iter!(&matrices.b))
             .for_each(|(((a, b), at_i), bt_i)| {
-                *a = evaluate_constraint(&at_i, &full_assignment);
-                *b = evaluate_constraint(&bt_i, &full_assignment);
+                *a = evaluate_constraint(at_i, full_assignment);
+                *b = evaluate_constraint(bt_i, full_assignment);
             });
 
         {
@@ -214,7 +217,7 @@ impl R1CSToQAP for LibsnarkReduction {
         cfg_iter_mut!(c[..num_constraints])
             .enumerate()
             .for_each(|(i, c)| {
-                *c = evaluate_constraint(&matrices.c[i], &full_assignment);
+                *c = evaluate_constraint(&matrices.c[i], full_assignment);
             });
 
         domain.ifft_in_place(&mut c);


### PR DESCRIPTION
## Description

This PR addresses several Clippy warnings to improve code quality and readability:

- Fixed needless borrows in r1cs_to_qap.rs by removing redundant references in evaluate_constraint calls
- Added type alias QapInstanceResult<F> to reduce type complexity in function signatures
- Improved lib.rs by removing redundant question mark operator and needless borrows in verify_with_processed_vk
- Reduced function argument count in generator.rs by introducing ParameterGenConfig struct to group related parameters

These changes make the code more idiomatic without affecting functionality.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
