### PR TITLE
fix: require at least one digit in changelog linkification regex

### DIFF
--- a/scripts/linkify_changelog.py
+++ b/scripts/linkify_changelog.py
@@ -26,6 +26,6 @@ if repo_name == "":
     repo_name = components[-2]
 
 for line in fileinput.input(inplace=True):
-    line = re.sub(r"\- #([0-9]*)", r"- [\\#\1](https://github.com/arkworks-rs/" + repo_name + r"/pull/\1)", line.rstrip())
+    line = re.sub(r"\- #([0-9]+)", r"- [#\1](https://github.com/arkworks-rs/" + repo_name + r"/pull/\1)", line.rstrip())
     # edits the current file
     print(line)


### PR DESCRIPTION
Refined the regular expression in linkify_changelog.py to require at least one digit after the # symbol when converting issue or pull request references to Markdown links.
This prevents the creation of invalid links for cases where no number is present (e.g., - #).
Also removed unnecessary escaping of the # character in the generated Markdown link.
This change improves the robustness and correctness of the changelog linkification script.