### PR TITLE
chore(ci): upgrade checkout to v5 and align crypto primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -41,7 +41,7 @@ jobs:
           - nightly
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
+ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives.git" }
 ark-relations = { git = "https://github.com/arkworks-rs/snark.git" }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra.git" }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra.git" }


### PR DESCRIPTION
## Summary

- Upgrade actions/checkout to v5.
- Patch ark-crypto-primitives to the merged num-bigint 0.5 compatibility fix.

## Why

The current algebra Git patch resolves ark-serialize with num-bigint 0.5, while the published ark-crypto-primitives 0.6 crate uses 0.4. The resulting incompatible BigUint types make the updated CI fail in Rescue serialization derives.

## Validation

- cargo +nightly check --all-features --examples --benches
- cargo +stable test --all-features
- cargo +stable build --no-default-features --target aarch64-unknown-none