### PR TITLE
Add length check in prepare_inputs for Groth16 verifier

### DIFF
--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -5,7 +5,7 @@ use crate::{r1cs_to_qap::R1CSToQAP, Groth16};
 
 use super::{PreparedVerifyingKey, Proof, VerifyingKey};
 
-use ark_relations::gr1cs::Result as R1CSResult;
+use ark_relations::gr1cs::{Result as R1CSResult, SynthesisError};
 
 use core::ops::{AddAssign, Neg};
 
@@ -26,6 +26,12 @@ impl<E: Pairing, QAP: R1CSToQAP> Groth16<E, QAP> {
         pvk: &PreparedVerifyingKey<E>,
         public_inputs: &[E::ScalarField],
     ) -> R1CSResult<E::G1> {
+        // Ensure the number of provided public inputs matches the verification key query length.
+        // Expected: gamma_abc_g1 has 1 extra element accounting for the constant term.
+        if public_inputs.len() + 1 != pvk.vk.gamma_abc_g1.len() {
+            return Err(SynthesisError::AssignmentMissing);
+        }
+
         let mut g_ic = pvk.vk.gamma_abc_g1[0].into_group();
         for (i, b) in public_inputs.iter().zip(pvk.vk.gamma_abc_g1.iter().skip(1)) {
             g_ic.add_assign(&b.mul_bigint(i.into_bigint()));


### PR DESCRIPTION
Add explicit validation that public_inputs.len() + 1 equals pvk.vk.gamma_abc_g1.len() and return an error on mismatch. This prevents silent truncation by zip when the number of public inputs is incorrect, aligning native verification behavior with the gadget verifier where input length is asserted. Ensures predictable API behavior and avoids subtle verification misuses.