### PR TITLE
Merge release/0.6.0 into master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,29 +21,29 @@ edition = "2021"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-ff = { version = "0.6", git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
-ark-ec = { version = "0.6", git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
-ark-serialize = { version = "0.6", git = "https://github.com/arkworks-rs/algebra.git", default-features = false, features = [ "derive" ] }
-ark-poly = { version = "0.6", git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
+ark-ff = { version = "0.6", default-features = false }
+ark-ec = { version = "0.6", default-features = false }
+ark-serialize = { version = "0.6", default-features = false, features = [ "derive" ] }
+ark-poly = { version = "0.6", default-features = false }
 ark-std = { version = "0.6.0", default-features = false }
 
-ark-relations = { version = "0.6", git = "https://github.com/arkworks-rs/snark.git", default-features = false }
-ark-snark = { version = "0.6", git = "https://github.com/arkworks-rs/snark.git", default-features = false }
+ark-relations = { version = "0.6", default-features = false }
+ark-snark = { version = "0.6", default-features = false }
 
-ark-r1cs-std = { version = "0.6", git = "https://github.com/arkworks-rs/r1cs-std.git", default-features = false, optional = true }
-ark-crypto-primitives = { version = "0.6", git = "https://github.com/arkworks-rs/crypto-primitives.git", default-features = false, features = [ "snark", "sponge" ] }
+ark-r1cs-std = { version = "0.6", default-features = false, optional = true }
+ark-crypto-primitives = { version = "0.6", default-features = false, features = [ "snark", "sponge" ] }
 tracing = { version = "0.1", default-features = false, features = ["attributes" ], optional = true }
 educe = { version = "0.6.0", default-features = false, features = [ "Clone" ], optional = true }
 
 rayon = { version = "1", optional = true }
 
 [dev-dependencies]
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false, features = [ "curve" ] }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false, features = [ "curve" ] }
-ark-bn254 = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false, features = [ "curve" ] }
-ark-bw6-761 = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
-ark-mnt4-298 = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false, features = [ "curve", "r1cs" ] }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std.git", default-features = true }
+ark-bls12-381 = { version = "0.6.0", default-features = false, features = [ "curve" ] }
+ark-bls12-377 = { version = "0.6.0", default-features = false, features = [ "curve" ] }
+ark-bn254 = { version = "0.6.0", default-features = false, features = [ "curve" ] }
+ark-bw6-761 = { version = "0.6.0", default-features = false }
+ark-mnt4-298 = { version = "0.6.0", default-features = false, features = [ "curve", "r1cs" ] }
+ark-r1cs-std = { version = "0.6.0", default-features = true }
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-groth16"
-version = "0.5.0"
+version = "0.6.0"
 authors = [ "arkworks contributors" ]
 description = "An implementation of the Groth 2016 zkSNARK proof system"
 homepage = "https://arkworks.rs"
@@ -21,17 +21,17 @@ edition = "2021"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false, features = [ "derive" ] }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
-ark-std = { version = "0.5.0", default-features = false }
+ark-ff = { version = "0.6", git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
+ark-ec = { version = "0.6", git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
+ark-serialize = { version = "0.6", git = "https://github.com/arkworks-rs/algebra.git", default-features = false, features = [ "derive" ] }
+ark-poly = { version = "0.6", git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
+ark-std = { version = "0.6.0", default-features = false }
 
-ark-relations = { git = "https://github.com/arkworks-rs/snark.git", default-features = false }
-ark-snark = { git = "https://github.com/arkworks-rs/snark.git", default-features = false }
+ark-relations = { version = "0.6", git = "https://github.com/arkworks-rs/snark.git", default-features = false }
+ark-snark = { version = "0.6", git = "https://github.com/arkworks-rs/snark.git", default-features = false }
 
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std.git", default-features = false, optional = true }
-ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives.git", default-features = false, features = [ "snark", "sponge" ] }
+ark-r1cs-std = { version = "0.6", git = "https://github.com/arkworks-rs/r1cs-std.git", default-features = false, optional = true }
+ark-crypto-primitives = { version = "0.6", git = "https://github.com/arkworks-rs/crypto-primitives.git", default-features = false, features = [ "snark", "sponge" ] }
 tracing = { version = "0.1", default-features = false, features = ["attributes" ], optional = true }
 educe = { version = "0.6.0", default-features = false, features = [ "Clone" ], optional = true }
 


### PR DESCRIPTION
## Summary

- merge the v0.6.0 package and dependency updates back into master
- align the arkworks dependency graph on the 0.6 release line
- replace the mixed floating 0.5/0.6 dependency resolution currently breaking CI

## Motivation

master still declares the 0.5 package/dependency versions while several floating git dependencies have advanced to 0.6. Cargo consequently resolves both ark-ff 0.5 and 0.6; ark-crypto-primitives from its 0.5 master imports SmallFp, but is compiled against crates.io ark-ff 0.5, which does not provide it.

The release/0.6.0 manifest uses a version-aligned 0.6 graph. A local cargo +stable check --all-features --lib on that branch completes successfully.

Merging this first also gives dependency-update PRs such as #94 a clean base.