### PR TITLE
docs: fix README and contributing grammar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,14 @@
 
 Thank you for considering making contributions to `arkworks-rs/groth16`!
 
-Contributing to this repo can be done in several forms, such as participating in discussion or proposing code changes. 
+Contributing to this repo can be done in several forms, such as participating in discussion or proposing code changes.
 To ensure a smooth workflow for all contributors, the following general procedure for contributing has been established:
 
 1) Either open or find an issue you'd like to help with
 2) Participate in thoughtful discussion on that issue
 3) If you would like to contribute:
     * If the issue is a feature proposal, ensure that the proposal has been accepted
-    * Ensure that nobody else has already begun working on this issue. 
+    * Ensure that nobody else has already begun working on this issue.
     If they have, please try to contact them to collaborate
     * If nobody has been assigned for the issue and you would like to work on it, make a comment on the issue to inform the community of your intentions to begin work. (So we can avoid duplication of efforts)
     * We suggest using standard Github best practices for contributing: fork the repo, branch from the HEAD of master, make some commits on your branch, and submit a PR from the branch to master.
@@ -17,7 +17,7 @@ To ensure a smooth workflow for all contributors, the following general procedur
     * Be sure to include a relevant change log entry in the Pending section of CHANGELOG.md (see file for log format)
         * If the change is breaking, we may add migration instructions.
 
-Note that for very small or clear problems (such as typos), or well isolated improvements, it is not required to an open issue to submit a PR.
+Note that for very small or clear problems (such as typos), or well isolated improvements, it is not required to open an issue to submit a PR.
 But be aware that for more complex problems/features touching multiple parts of the codebase, if a PR is opened before an adequate design discussion has taken place in a github issue, that PR runs a larger likelihood of being rejected.
 
 Looking for a good place to start contributing? How about checking out some good first issues
@@ -50,16 +50,16 @@ and then work as normal on that branch, and pull request to upstream master when
 ## Updating documentation
 
 All PRs should aim to leave the code more documented than it started with.
-Please don't assume that its easy to infer what the code is doing, 
-as that is usually not the case for these complex protocols. 
+Please don't assume that it's easy to infer what the code is doing,
+as that is usually not the case for these complex protocols.
 (Even when you understand the paper!)
 
-Its often very useful to describe what is the high level view of what a code block is doing,
+It's often very useful to describe what is the high level view of what a code block is doing,
 and either refer to the relevant section of a paper or include a short proof/argument for why it makes sense before the actual logic.
 
 ## Performance improvements
 
 All performance improvements should be accompanied with benchmarks improving, or otherwise have it be clear that things have improved.
 For some areas of the codebase, performance roughly follows the number of field multiplications, but there are also many areas where
-hard to predict low level system effects such as cache locality and superscalar operations become important for performance. 
+hard to predict low level system effects such as cache locality and superscalar operations become important for performance.
 Thus performance can often become very non-intuitive / diverge from minimizing the number of arithmetic operations.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://deps.rs/repo/github/arkworks-rs/groth16"><img src="https://deps.rs/repo/github/arkworks-rs/groth16/status.svg"></a>
 </p>
 
-The arkworks ecosystem consist of Rust libraries for designing and working with __zero knowledge succinct non-interactive arguments (zkSNARKs)__. This repository contains an efficient implementation of the zkSNARK of [[Groth16]](https://eprint.iacr.org/2016/260).
+The arkworks ecosystem consists of Rust libraries for designing and working with __zero knowledge succinct non-interactive arguments (zkSNARKs)__. This repository contains an efficient implementation of the zkSNARK of [[Groth16]](https://eprint.iacr.org/2016/260).
 
 This library is released under the MIT License and the Apache v2 License (see [License](#license)).
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR fixes a few small grammar issues and trailing spaces in `README.md` and `CONTRIBUTING.md`.

The changes are documentation-only and do not affect any Groth16 implementation, tests, APIs, or cryptographic behavior.

Changelog entry is not included because this is a docs-only grammar cleanup.




closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
